### PR TITLE
Adding support for configuring access to different S3 endpoints for testing

### DIFF
--- a/clients/storage/storage-client.js
+++ b/clients/storage/storage-client.js
@@ -9,16 +9,7 @@ import {
   // AbortMultipartUploadCommand,
 } from '@aws-sdk/client-s3';
 
-//
-
-const region = 'us-west-2';
-const bucketName = 'wiki.webaverse.com';
-
-//
-
 const encoding = 'hex';
-
-//
 
 const _getFileHash = async file => {
   const hash = crypto.createHash('sha3-256');
@@ -48,19 +39,34 @@ export class StorageClient {
       token: w3sApiKey,
     }); */
 
+    const region = process.env.AWS_REGION || 'us-west-2';
     const accessKeyId = process.env.AWS_ACCESS_KEY_ID_WEBAVERSE;
     const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY_WEBAVERSE;
+    const bucketName = process.env.AWS_BUCKET_NAME_WEBAVERSE || 'wiki.webaverse.com';
+    const endpoint = process.env.AWS_ENDPOINT_WEBAVERSE;
+    const urlBase = process.env.AWS_S3_URL_BASE_WEBAVERSE || `https://s3.${region}.amazonaws.com`;
+
     if (!accessKeyId || !secretAccessKey) {
       throw new Error('no aws access key found');
     }
-    this.client = new S3Client({
+
+    let s3ClientConfig = {
       region,
       // bucketName,
       credentials: {
         accessKeyId,
         secretAccessKey,
       },
-    });
+    };
+
+    // Allow overwriting the S3 endpoint URL for testing purposes
+    if (endpoint) {
+      s3ClientConfig.endpoint = endpoint;
+    }
+
+    this.bucketUrlBase = `${urlBase}/${bucketName}`;
+
+    this.client = new S3Client(s3ClientConfig);
   }
   async uploadFile(file) {
     const {name} = file;
@@ -104,7 +110,7 @@ export class StorageClient {
       const {name} = file;
 
       const ab = await file.arrayBuffer();
-      
+
       // console.log('put objects 1', {
       //   Bucket: bucketName,
       //   Key: `${metaHash}/${name}`,
@@ -133,6 +139,6 @@ export class StorageClient {
   } */
   getUrl(hash, name) {
     // return `https://w3s.link/ipfs/${hash}/${name}`;
-    return `https://s3.${region}.amazonaws.com/${bucketName}/${hash}/${name}`;
+    return `${this.bucketUrlBase}/${hash}/${name}`;
   }
 }


### PR DESCRIPTION
Adding some flexibility around AWS configs to allow using a local S3 service (such as https://github.com/webaverse/local-s3).

This would allow testing locally without the need of real AWS credentials:

`AWS_ACCESS_KEY_ID_WEBAVERSE=webaverse AWS_SECRET_ACCESS_KEY_WEBAVERSE=webaverse AWS_ENDPOINT_WEBAVERSE=http://localhost:4566 AWS_S3_URL_BASE_WEBAVERSE=http://s3.localhost.localstack.cloud:4566 npm run dev`